### PR TITLE
apply jobspec diff to in progress jobs

### DIFF
--- a/daemon/lib.go
+++ b/daemon/lib.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -18,14 +19,9 @@ const (
 	mutexKeyJobCreation = "job-creation"
 )
 
-type JobInAction struct {
-	Cmd *exec.Cmd
-}
-
 type JobDefinition struct {
 	CmdStr  string
 	Args    []string
-	Env     map[string]string
 	ExecCmd *exec.Cmd
 	ActionsUp
 }
@@ -67,7 +63,10 @@ func (j *JobDefinition) InitJob() {
 	err := cmd.Start()
 
 	// when cmd.Wait() completes, j.ExecCmd.ProcessState will be attached
-	go func() { cmd.Wait(); j.Dispatch(string(Display)) }()
+	go func() {
+		cmd.Wait()
+		j.Dispatch(string(Display))
+	}()
 
 	if err != nil {
 		fmt.Println("that's bad")
@@ -76,12 +75,14 @@ func (j *JobDefinition) InitJob() {
 }
 
 type Daemon struct {
-	Ev ActionsUp
-	//portAvailability map[int]bool
+	Ev                 ActionsUp
 	Jobs               []*JobDefinition
+	AbandonedJobs      []*JobDefinition
 	lastReport, report string
 	shutdownMut        *sync.Mutex
 	util.MultiMutex
+	loadJobSpec         func() ([][]string, error)
+	currentJobSpecLines [][]string
 }
 
 func (d *Daemon) Exit(code int8) {
@@ -112,21 +113,25 @@ type ActionsUp interface {
 	Exit(code int8)
 }
 
-func New(cmdLines [][]string) *Daemon {
+func New(loadJobSpec func() ([][]string, error)) *Daemon {
 	d := &Daemon{
 		shutdownMut: &sync.Mutex{},
 		MultiMutex:  util.NewMultiMutex(),
 	}
+	d.loadJobSpec = loadJobSpec
+	cmdLines := util.Must(loadJobSpec())
+	d.currentJobSpecLines = cmdLines
 	jobs := d.JobSpec(cmdLines)
 	d.Jobs = jobs
 	return d
 }
 
 const (
-	Display           = EventString("display")
-	IntervalDisplay   = EventString("interval-display")
-	IntervalKeepAlive = EventString("interval-keep-alive")
-	IntervalSelfCheck = EventString("interval-self-check")
+	Display                       = EventString("display")
+	IntervalDisplay               = EventString("interval-display")
+	IntervalKeepAlive             = EventString("interval-keep-alive")
+	IntervalSelfCheck             = EventString("interval-self-check")
+	IntervalSelUpdateToNewJobDesc = EventString("interval-self-update-to-new-job-desc")
 )
 
 type EventString string
@@ -144,42 +149,55 @@ func (d *Daemon) DisplayDebug() {
 		Args   []string
 	}
 	var xx []string
-	xx = util.Map_tu(d.Jobs, func(j *JobDefinition) string {
-		status := j.Status()
+	var makeReport = func(jobs []*JobDefinition) string {
+		xx = util.Map_tu(jobs, func(j *JobDefinition) string {
+			status := j.Status()
 
-		view := miniDef{
-			Status: status,
-			Id:     0,
-			Cmd:    j.CmdStr,
-			Args:   j.Args,
-		}
-
-		switch status {
-		case "missing":
-			view.Id = -1
-		case "running":
-			view.Id = -2
-			if j.ExecCmd != nil &&
-				j.ExecCmd.Process != nil {
-				view.Id = j.ExecCmd.Process.Pid
+			view := miniDef{
+				Status: status,
+				Id:     0,
+				Cmd:    j.CmdStr,
+				Args:   j.Args,
 			}
-		case "exited":
-			if j.ExecCmd != nil &&
-				j.ExecCmd.Process != nil {
-				view.Id = j.ExecCmd.Process.Pid
+
+			switch status {
+			case "missing":
+				view.Id = -1
+			case "running":
+				view.Id = -2
+				if j.ExecCmd != nil &&
+					j.ExecCmd.Process != nil {
+					view.Id = j.ExecCmd.Process.Pid
+				}
+			case "exited":
+				if j.ExecCmd != nil &&
+					j.ExecCmd.Process != nil {
+					view.Id = j.ExecCmd.Process.Pid
+				}
+			default:
+				panic("implement me: " + status)
 			}
-		default:
-			panic("implement me: " + status)
-		}
 
-		s, err := json.Marshal(view)
-		if err != nil {
-			return err.Error()
-		}
-		return string(s)
-	})
+			s, err := json.Marshal(view)
+			if err != nil {
+				return err.Error()
+			}
+			return string(s)
+		})
+		return strings.Join(xx, "\n")
+	}
+	clearedHeader := ""
+	if len(d.AbandonedJobs) != 0 {
+		clearedHeader = "====cleared jobs===="
+	}
+	report := fmt.Sprintf(
+		"=====in progress====\n%v\n%s\n%v",
+		makeReport(d.Jobs),
+		clearedHeader,
+		makeReport(d.AbandonedJobs),
+	)
+	d.report = report
 
-	d.report = strings.Join(xx, "\n")
 	if d.report != d.lastReport {
 		fmt.Println("pid", os.Getpid())
 		fmt.Println(d.report)
@@ -194,7 +212,6 @@ func (d *Daemon) JobSpec(cmdLines [][]string) (jobs []*JobDefinition) {
 		job := JobDefinition{
 			CmdStr:    cmd,
 			Args:      args,
-			Env:       nil,
 			ActionsUp: d,
 		}
 		jobs = append(jobs, &job)
@@ -214,7 +231,7 @@ func (d *Daemon) FixMissing() {
 func (d *Daemon) RegisterListeners() {
 	d.AddListener(IntervalDisplay, func(ctx context.Context) error {
 		d.DisplayDebug()
-		time.Sleep(5000 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 		d.Ev.Dispatch(string(IntervalDisplay))
 		return nil
 	})
@@ -239,22 +256,75 @@ func (d *Daemon) RegisterListeners() {
 		return nil
 	})
 
+	var stopJobBlocking = func(job *JobDefinition, extraDesc string) {
+		if job.ExecCmd != nil &&
+			job.ExecCmd.Process != nil {
+			fmt.Println("killing", extraDesc, job.ExecCmd.Process.Pid)
+			err := job.ExecCmd.Process.Kill()
+			if err != nil &&
+				err.Error() != "os: process already finished" {
+				fmt.Println("trouble killing")
+				fmt.Println(reflect.TypeOf(err))
+				fmt.Println(err.Error())
+			}
+		}
+	}
+
+	var UpdateToNewJobDesc = func() {
+		// don't start or mutate jobs when determining if we need to totally change what jobs are running
+		d.LockOn(mutexKeyJobCreation, func() {
+			newJobSpecLines, err := d.loadJobSpec()
+			if err != nil {
+				fmt.Println("Error updating jobspec!!")
+				fmt.Println(err.Error())
+				return
+			}
+			newJobSpec := d.JobSpec(newJobSpecLines)
+
+			if !reflect.DeepEqual(newJobSpecLines, d.currentJobSpecLines) {
+				d.currentJobSpecLines = newJobSpecLines
+				oldJobSpec := d.Jobs
+				toKeep, toRemove, toAdd := describeDiff(slices.Clone(newJobSpec), slices.Clone(oldJobSpec))
+				fmt.Println("remove", toRemove)
+				fmt.Println("add", util.Map_tu(toAdd, func(jd *JobDefinition) string {
+					return fmt.Sprintf("%v %v", jd.CmdStr, jd.Args)
+				}))
+
+				d.AbandonedJobs = []*JobDefinition{}
+				if len(toKeep) != len(newJobSpec) || len(toRemove) != 0 || len(toAdd) != 0 {
+					for _, entry := range toRemove {
+						toRemove := d.Jobs[entry.index]
+						stopJobBlocking(toRemove, "(extra after conf load)")
+						d.Jobs[entry.index] = nil
+						d.AbandonedJobs = append(d.AbandonedJobs, toRemove)
+					}
+
+					d.Jobs = util.Filter(d.Jobs, func(job *JobDefinition) bool {
+						return job != nil
+					})
+
+					for _, newJob := range toAdd {
+						d.Jobs = append(d.Jobs, newJob)
+					}
+				}
+				d.currentJobSpecLines = newJobSpecLines
+			}
+		})
+	}
+
+	d.AddListener(IntervalSelUpdateToNewJobDesc, func(ctx context.Context) error {
+		UpdateToNewJobDesc()
+		time.Sleep(150 * time.Millisecond)
+		d.Ev.Dispatch(string(IntervalSelUpdateToNewJobDesc))
+		return nil
+	})
+
 	d.AddListener(event_loop.Signal, func(ctx context.Context) error {
 		// block job creation while shutting down
 		d.LockOn(mutexKeyJobCreation, func() {
 			d.shutdownMut.Lock()
 			for i, job := range d.Jobs {
-				if job.ExecCmd != nil &&
-					job.ExecCmd.Process != nil {
-					fmt.Println("killing", i, job.ExecCmd.Process.Pid)
-					err := job.ExecCmd.Process.Kill()
-					if err != nil &&
-						err.Error() != "os: process already finished" {
-						fmt.Println("trouble killing")
-						fmt.Println(reflect.TypeOf(err))
-						fmt.Println(err.Error())
-					}
-				}
+				stopJobBlocking(job, fmt.Sprintf("%v", i))
 			}
 			time.Sleep(20 * time.Millisecond)
 			d.Ev.(*event_loop.EventLoop).ExitBlocking(0)
@@ -262,4 +332,50 @@ func (d *Daemon) RegisterListeners() {
 		return nil
 	})
 
+}
+
+type sliceEntry[T any] struct {
+	index int
+	t     T
+}
+
+type compare struct {
+	Cmd  string
+	Args []string
+}
+
+func describeDiff(newJobs, oldJobs []*JobDefinition) (toKeep []sliceEntry[compare], toRemove []sliceEntry[compare], toAdd []*JobDefinition) {
+	for i, j := range oldJobs {
+		found := -1
+		for ii, jj := range newJobs {
+			if jj != nil && reflect.DeepEqual(compare{
+				Cmd:  j.CmdStr,
+				Args: j.Args,
+			}, compare{
+				Cmd:  jj.CmdStr,
+				Args: jj.Args,
+			}) {
+				found = ii
+				break
+			}
+		}
+		if found > -1 {
+			newJobs[found] = nil
+			toKeep = append(toKeep, sliceEntry[compare]{i, compare{
+				Cmd:  j.CmdStr,
+				Args: j.Args,
+			}})
+		} else {
+			toRemove = append(toRemove, sliceEntry[compare]{i, compare{
+				Cmd:  j.CmdStr,
+				Args: j.Args,
+			}})
+		}
+	}
+	for _, j := range newJobs {
+		if j != nil {
+			toAdd = append(toAdd, j)
+		}
+	}
+	return
 }

--- a/daemon/lib_test.go
+++ b/daemon/lib_test.go
@@ -1,0 +1,124 @@
+package daemon_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/mweitzel/phost/daemon"
+	"github.com/mweitzel/phost/event_loop"
+	"github.com/mweitzel/phost/util"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func waitUntil(ev *event_loop.EventLoop, event event_loop.MatchStringer) *sync.WaitGroup {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	var id int
+	id = ev.AddListener(event, func(ctx context.Context) error {
+		wg.Done()
+		ev.RemoveListener(id)
+		return nil
+	})
+	return wg
+}
+
+func TestUpdatesJobs(t *testing.T) {
+	var contents = "echo hi there\necho bye now"
+	var pContents = &contents
+
+	d, ev := newDaemon(pContents)
+	ev.Run()
+
+	// twice in case the actual work one receives its event first
+	waitUntil(ev, daemon.IntervalSelfCheck).Wait()
+	waitUntil(ev, daemon.IntervalSelfCheck).Wait()
+
+	jobsInitial := ""
+	ev.LockOn("pause", func() {
+		jobDesc := util.Map_tu(d.Jobs, func(j *daemon.JobDefinition) string {
+			return fmt.Sprint(j.CmdStr, j.Args)
+		})
+		jobsInitial = strings.Join(jobDesc, "\n")
+	})
+
+	contents = "echo new stuff\necho bye now"
+
+	waitUntil(ev, daemon.IntervalSelUpdateToNewJobDesc).Wait()
+	waitUntil(ev, daemon.IntervalSelUpdateToNewJobDesc).Wait()
+
+	jobsUpdated := " "
+	ev.LockOn("pause", func() {
+		jobDesc := util.Map_tu(d.Jobs, func(j *daemon.JobDefinition) string {
+			return fmt.Sprint(j.CmdStr, j.Args)
+		})
+		jobsUpdated = strings.Join(jobDesc, "\n")
+	})
+
+	if jobsInitial == jobsUpdated {
+		t.Errorf("jobs match but should not \n%v\n------------\n%v", jobsInitial, jobsUpdated)
+		t.FailNow()
+	}
+
+	expectedDesc := strings.Join([]string{
+		"echo[bye now]",   // original (second entry)
+		"echo[new stuff]", // new job, appended
+	}, "\n")
+	if expectedDesc != jobsUpdated {
+		t.Errorf("job does not match expected but should \n%v\n------------\n%v", expectedDesc, jobsUpdated)
+		t.FailNow()
+	}
+}
+
+func expect(t *testing.T, fn func() bool) {
+	if fn() {
+		return
+	}
+
+	_, file, line, _ := runtime.Caller(1)
+	contents := util.Must(os.ReadFile(file))
+	lines := strings.Split(string(contents), "\n")
+	t.Error(fmt.Sprintf("failed at %s:%d\n*  %v", file, line, strings.Join(lines[line-1:line+3], "\n*  ")))
+
+}
+
+func newDaemon(str *string) (*daemon.Daemon, *event_loop.EventLoop) {
+	d := daemon.New(func() ([][]string, error) {
+		jobspec := parseConf(*str)
+		return jobspec, nil
+	})
+	ev := event_loop.New()
+	d.Ev = ev
+	d.RegisterListeners()
+
+	ev.Dispatch(string(daemon.IntervalSelfCheck))
+	ev.Dispatch(string(daemon.IntervalKeepAlive))
+	ev.Dispatch(string(daemon.IntervalDisplay))
+	ev.Dispatch(string(daemon.IntervalSelUpdateToNewJobDesc))
+	ev.Dispatch(string(daemon.Display))
+
+	return d, ev
+}
+
+func parseConf(contents string) [][]string {
+	blankMatcher := regexp.MustCompile("^\\s*$")
+	lines := strings.Split(contents, "\n")
+	lines = util.Map_tt(lines, func(s string) string {
+		return strings.Split(s, "#")[0]
+	})
+	lines = util.Filter(lines, func(s string) bool {
+		return !blankMatcher.MatchString(s)
+	})
+	var cmds [][]string
+	cmds = util.Map_tu(lines, func(line string) []string {
+		tokens := strings.Split(line, " ")
+		tokens = util.Filter(tokens, func(s string) bool {
+			return len(s) > 0
+		})
+		return tokens
+	})
+	return cmds
+}

--- a/main.go
+++ b/main.go
@@ -21,9 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	jobspec := loadConf(jobspecPath)
-
-	d := daemon.New(jobspec)
+	d := daemon.New(confLoader(jobspecPath))
 	ev := event_loop.New()
 	d.Ev = ev
 	d.RegisterListeners()
@@ -31,6 +29,7 @@ func main() {
 	ev.Dispatch(string(daemon.IntervalSelfCheck))
 	ev.Dispatch(string(daemon.IntervalKeepAlive))
 	ev.Dispatch(string(daemon.IntervalDisplay))
+	ev.Dispatch(string(daemon.IntervalSelUpdateToNewJobDesc))
 	ev.Dispatch(string(daemon.Display))
 
 	go func() { ev.Run() }()
@@ -44,23 +43,30 @@ func usage() {
 	}, "\n"))
 }
 
-func loadConf(path string) [][]string {
-	contents := util.Must(os.ReadFile(path))
-	blankMatcher := regexp.MustCompile("^\\s*$")
-	lines := strings.Split(string(contents), "\n")
-	lines = util.Map_tt(lines, func(s string) string {
-		return strings.Split(s, "#")[0]
-	})
-	lines = util.Filter(lines, func(s string) bool {
-		return !blankMatcher.MatchString(s)
-	})
-	var cmds [][]string
-	cmds = util.Map_tu(lines, func(line string) []string {
-		tokens := strings.Split(line, " ")
-		tokens = util.Filter(tokens, func(s string) bool {
-			return len(s) > 0
+func confLoader(confPath string) func() ([][]string, error) {
+	return func() ([][]string, error) {
+		contents, err := os.ReadFile(confPath)
+		if err != nil {
+			return nil, err
+		}
+
+		blankMatcher := regexp.MustCompile("^\\s*$")
+		lines := strings.Split(string(contents), "\n")
+		lines = util.Map_tt(lines, func(s string) string {
+			return strings.Split(s, "#")[0]
 		})
-		return tokens
-	})
-	return cmds
+		lines = util.Filter(lines, func(s string) bool {
+			return !blankMatcher.MatchString(s)
+		})
+		var cmds [][]string
+		cmds = util.Map_tu(lines, func(line string) []string {
+			tokens := strings.Split(line, " ")
+			tokens = util.Filter(tokens, func(s string) bool {
+				return len(s) > 0
+			})
+			return tokens
+		})
+
+		return cmds, nil
+	}
 }


### PR DESCRIPTION
When an active `jobspec` file is updated, the daemon will apply the diff to the currently running jobs.
- Duplicate jobs are allowed
- Removing a jobspec line entry will remove/terminate a job
- Adding a line entry will add/initialize a new job
- Re-arranging line entries have no affect
- The job list debug view may not be in the order of the jobspec after modification